### PR TITLE
set series index to match legendIndex

### DIFF
--- a/__init__.js
+++ b/__init__.js
@@ -117,6 +117,7 @@ var $builtinmodule = function(name) {
 
     for(var i = 0; i < chart.series.length; i++) {
       chart.series[i].legendIndex = chart.series.length - i;
+      chart.series[i].index = chart.series.length - i;
     }
 
     if (renderer) {


### PR DESCRIPTION
Fixes multi series graphs, where the order of e.g. bars is exactly reversed from the legend 

in this example the blue 'Other' bar is the first series on the left of each year, when it should be on the right:
https://trinket.io/python/c6d430cb19
