### PR TITLE
Checks that keyword arg value is defined. Fixes #4.

### DIFF
--- a/__init__.js
+++ b/__init__.js
@@ -171,11 +171,15 @@ var $builtinmodule = function(name) {
       });
 
       $loc.render = new Sk.builtin.func(function(self) {
-        var i, key;
+        var i, key, val;
 
         for (i = 0; i < KWARGS.length; i++) {
           key = KWARGS[i];
-          self.instance._options[key] = Sk.ffi.remapToJs(self.tp$getattr(key));
+          val = self.tp$getattr(key);
+
+          if (typeof val !== "undefined") {
+            self.instance._options[key] = Sk.ffi.remapToJs(val);
+          }
         }
 
         return self.instance.render(renderer);


### PR DESCRIPTION
Makes sure any values added since the constructor was called are actually defined before adding them to options.